### PR TITLE
fix batch normalization usage bug under tensorflow framework.

### DIFF
--- a/MCTS.py
+++ b/MCTS.py
@@ -76,8 +76,17 @@ class MCTS():
             # leaf node
             self.Ps[s], v = self.nnet.predict(canonicalBoard)
             valids = self.game.getValidMoves(canonicalBoard, 1)
+            ps_no_masking = np.copy(self.Ps[s])
+
             self.Ps[s] = self.Ps[s]*valids      # masking invalid moves
-            self.Ps[s] /= np.sum(self.Ps[s])    # renormalize
+            t = np.sum(self.Ps[s])
+            if not np.isclose(t, 0):
+                self.Ps[s] /= t; #renomalize
+            else:
+                print('sum of self.Ps[s] after masking is too small: {}'.format(t))
+                print('current board state s : {}'.format(s))
+                print('self.Ps[s] after masking : {}'.format(self.Ps[s]))
+                print('self.Ps[s] without masking: {}'.format(ps_no_masking))
 
             self.Vs[s] = valids
             self.Ns[s] = 0

--- a/othello/OthelloLogic.py
+++ b/othello/OthelloLogic.py
@@ -108,7 +108,7 @@ class Board():
         # print(move)
         flips = [flip for direction in self.__directions
                       for flip in self._get_flips(move, direction, color)]
-        assert len(list(flips))>0
+        #assert len(list(flips))>0
         for x, y in flips:
             #print(self[x][y],color)
             self[x][y] = color

--- a/othello/OthelloPlayers.py
+++ b/othello/OthelloPlayers.py
@@ -24,7 +24,7 @@ class HumanOthelloPlayer():
             if valid[i]:
                 print(int(i/self.game.n), int(i%self.game.n))
         while True:
-        	a = input()
+        	a = raw_input()
 
         	x,y = [int(x) for x in a.split(' ')]
         	a = self.game.n * x + y if x!= -1 else self.game.n ** 2

--- a/othello/tensorflow/NNet.py
+++ b/othello/tensorflow/NNet.py
@@ -55,7 +55,7 @@ class NNetWrapper(NeuralNet):
                 boards, pis, vs = list(zip(*[examples[i] for i in sample_ids]))
 
                 # predict and compute gradient and do SGD step
-                input_dict = {self.nnet.input_boards: boards, self.nnet.target_pis: pis, self.nnet.target_vs: vs, self.nnet.dropout: args.dropout}
+                input_dict = {self.nnet.input_boards: boards, self.nnet.target_pis: pis, self.nnet.target_vs: vs, self.nnet.dropout: args.dropout, self.nnet.isTraining: True}
 
                 # measure data loading time
                 data_time.update(time.time() - end)
@@ -97,11 +97,10 @@ class NNetWrapper(NeuralNet):
         board = board[np.newaxis, :, :]
 
         # run
-        pi, v = self.sess.run([self.nnet.pi, self.nnet.v], feed_dict={self.nnet.input_boards: board, self.nnet.dropout: 0})
+        prob, v = self.sess.run([self.nnet.prob, self.nnet.v], feed_dict={self.nnet.input_boards: board, self.nnet.dropout: 0, self.nnet.isTraining: False})
 
         #print('PREDICTION TIME TAKEN : {0:03f}'.format(time.time()-start))
-        pi = np.exp(pi) / np.sum(np.exp(pi))
-        return pi[0], v[0]
+        return prob[0], v[0]
 
     def save_checkpoint(self, folder='checkpoint', filename='checkpoint.pth.tar'):
         filepath = os.path.join(folder, filename)

--- a/othello/tensorflow/OthelloNNet.py
+++ b/othello/tensorflow/OthelloNNet.py
@@ -23,17 +23,19 @@ class OthelloNNet():
         with self.graph.as_default(): 
             self.input_boards = tf.placeholder(tf.float32, shape=[None, self.board_x, self.board_y])    # s: batch_size x board_x x board_y
             self.dropout = tf.placeholder(tf.float32)
+            self.isTraining = tf.placeholder(tf.bool, name="is_training")
 
             x_image = tf.reshape(self.input_boards, [-1, self.board_x, self.board_y, 1])                    # batch_size  x board_x x board_y x 1
-            h_conv1 = Relu(BatchNormalization(self.conv2d(x_image, args.num_channels, 'same'), axis=3))     # batch_size  x board_x x board_y x num_channels
-            h_conv2 = Relu(BatchNormalization(self.conv2d(h_conv1, args.num_channels, 'same'), axis=3))     # batch_size  x board_x x board_y x num_channels
-            h_conv3 = Relu(BatchNormalization(self.conv2d(h_conv2, args.num_channels, 'valid'), axis=3))    # batch_size  x (board_x-2) x (board_y-2) x num_channels
-            h_conv4 = Relu(BatchNormalization(self.conv2d(h_conv3, args.num_channels, 'valid'), axis=3))    # batch_size  x (board_x-4) x (board_y-4) x num_channels
+            h_conv1 = Relu(BatchNormalization(self.conv2d(x_image, args.num_channels, 'same'), axis=3, training=self.isTraining))     # batch_size  x board_x x board_y x num_channels
+            h_conv2 = Relu(BatchNormalization(self.conv2d(h_conv1, args.num_channels, 'same'), axis=3, training=self.isTraining))     # batch_size  x board_x x board_y x num_channels
+            h_conv3 = Relu(BatchNormalization(self.conv2d(h_conv2, args.num_channels, 'valid'), axis=3, training=self.isTraining))    # batch_size  x (board_x-2) x (board_y-2) x num_channels
+            h_conv4 = Relu(BatchNormalization(self.conv2d(h_conv3, args.num_channels, 'valid'), axis=3, training=self.isTraining))    # batch_size  x (board_x-4) x (board_y-4) x num_channels
             h_conv4_flat = tf.reshape(h_conv4, [-1, args.num_channels*(self.board_x-4)*(self.board_y-4)])
-            s_fc1 = Dropout(Relu(BatchNormalization(Dense(h_conv4_flat, 1024), axis=1)), rate=self.dropout) # batch_size x 1024
-            s_fc2 = Dropout(Relu(BatchNormalization(Dense(s_fc1, 512), axis=1)), rate=self.dropout)         # batch_size x 512
+            s_fc1 = Dropout(Relu(BatchNormalization(Dense(h_conv4_flat, 1024), axis=1, training=self.isTraining)), rate=self.dropout) # batch_size x 1024
+            s_fc2 = Dropout(Relu(BatchNormalization(Dense(s_fc1, 512), axis=1, training=self.isTraining)), rate=self.dropout)         # batch_size x 512
             self.pi = Dense(s_fc2, self.action_size)                                                        # batch_size x self.action_size
             self.v = Tanh(Dense(s_fc2, 1))                                                               # batch_size x 1
+            self.prob = tf.nn.softmax(self.pi)
 
             self.calculate_loss()
 
@@ -46,7 +48,9 @@ class OthelloNNet():
         self.loss_pi =  tf.losses.softmax_cross_entropy(self.target_pis, self.pi)
         self.loss_v = tf.losses.mean_squared_error(self.target_vs, tf.reshape(self.v, shape=[-1,]))
         self.total_loss = self.loss_pi + self.loss_v
-        self.train_step = tf.train.AdamOptimizer(self.args.lr).minimize(self.total_loss)
+        update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
+        with tf.control_dependencies(update_ops):
+            self.train_step = tf.train.AdamOptimizer(self.args.lr).minimize(self.total_loss)
 
 
 


### PR DESCRIPTION
1. fix batch normalization usage bug under tensorflow
2. Log the detailed message when masked probability value is very small
3. use raw_input, instead of input