### PR TITLE
fix issue: Bug in getGameEnded() / GoBang #40

### DIFF
--- a/gobang/GobangGame.py
+++ b/gobang/GobangGame.py
@@ -68,7 +68,7 @@ class GobangGame(Game):
                 if (w in range(self.n - n + 1) and h in range(self.n - n + 1) and board[w][h] != 0 and
                         len(set(board[w + k][h + k] for k in range(n))) == 1):
                     return board[w][h]
-                if (w in range(self.n - n + 1) and h in range(self.n - n + 1, self.n) and board[w][h] != 0 and
+                if (w in range(self.n - n + 1) and h in range(n - 1, self.n) and board[w][h] != 0 and
                         len(set(board[w + l][h - l] for l in range(n))) == 1):
                     return board[w][h]
         if b.has_legal_moves():


### PR DESCRIPTION
It seems that the range of the 4th rule in gobang getGameEnded is not appropriate.
I encounter this issue sometimes.