### PR TITLE
othello/pytorch: fix invalid index of 0-dim tensor error

### DIFF
--- a/othello/pytorch/NNet.py
+++ b/othello/pytorch/NNet.py
@@ -79,8 +79,8 @@ class NNetWrapper(NeuralNet):
                 total_loss = l_pi + l_v
 
                 # record loss
-                pi_losses.update(l_pi.data[0], boards.size(0))
-                v_losses.update(l_v.data[0], boards.size(0))
+                pi_losses.update(l_pi.item(), boards.size(0))
+                v_losses.update(l_v.item(), boards.size(0))
 
                 # compute gradient and do SGD step
                 optimizer.zero_grad()


### PR DESCRIPTION
Hitting IndexError with the previous form of the lines on pytorch 1.0 (probably error since 0.4.0).

Signed-off-by: Gergely Imreh <imrehg@gmail.com>