### PR TITLE
othello/pytorch: map storage to CPU if on CPU-only machine

### DIFF
--- a/othello/pytorch/NNet.py
+++ b/othello/pytorch/NNet.py
@@ -148,5 +148,6 @@ class NNetWrapper(NeuralNet):
         filepath = os.path.join(folder, filename)
         if not os.path.exists(filepath):
             raise("No model in path {}".format(filepath))
-        checkpoint = torch.load(filepath)
+        map_location = None if args.cuda else 'cpu'
+        checkpoint = torch.load(filepath, map_location=map_location)
         self.nnet.load_state_dict(checkpoint['state_dict'])


### PR DESCRIPTION
Otherwise won't be able to load existing checkpoints on a CPU-only machine.

Signed-off-by: Gergely Imreh <imrehg@gmail.com>