### PR TITLE
othello.keras.NNet: revise incorrect import

### DIFF
--- a/othello/keras/NNet.py
+++ b/othello/keras/NNet.py
@@ -11,7 +11,7 @@ from utils import *
 from NeuralNet import NeuralNet
 
 import argparse
-from OthelloNNet import OthelloNNet as onnet
+from .OthelloNNet import OthelloNNet as onnet
 
 args = dotdict({
     'lr': 0.001,


### PR DESCRIPTION
Change incorrect relative import to absolute import, so that the `main.py` can successfully be executed.