### PR TITLE
Network not punished for illegal moves

### DIFF
--- a/Arena.py
+++ b/Arena.py
@@ -55,7 +55,7 @@ class Arena():
             assert(self.display)
             print("Game over: Turn ", str(it), "Result ", str(self.game.getGameEnded(board, 1)))
             self.display(board)
-        return self.game.getGameEnded(board, 1)
+        return curPlayer*self.game.getGameEnded(board, curPlayer)
 
     def playGames(self, num, verbose=False):
         """

--- a/Coach.py
+++ b/Coach.py
@@ -49,7 +49,7 @@ class Coach():
             temp = int(episodeStep < self.args.tempThreshold)
 
             pi = self.mcts.getActionProb(canonicalBoard, temp=temp)
-            sym = self.game.getSymmetries(canonicalBoard, pi)
+            valids = self.game.getValidMoves(canonicalBoard, 1)
             
             # ideally these should be combined so that getSymmetries takes valids as well 
             bs, ps = zip(*self.game.getSymmetries(canonicalBoard, pi))

--- a/Coach.py
+++ b/Coach.py
@@ -50,8 +50,15 @@ class Coach():
 
             pi = self.mcts.getActionProb(canonicalBoard, temp=temp)
             sym = self.game.getSymmetries(canonicalBoard, pi)
-            for b,p in sym:
-                trainExamples.append([b, self.curPlayer, p, None])
+            
+            # ideally these should be combined so that getSymmetries takes valids as well 
+            bs, ps = zip(*self.game.getSymmetries(canonicalBoard, pi))
+            _, valids_sym = zip(*self.game.getSymmetries(canonicalBoard, valids))
+            sym = zip(bs,ps,valids_sym)
+            
+            for b,p,valid in sym:
+                # previous was: [b, self.curPlayer, p, None], but only 3 values were returned
+                trainExamples.append([b, self.curPlayer, p, valid])
 
             action = np.random.choice(len(pi), p=pi)
             board, self.curPlayer = self.game.getNextState(board, self.curPlayer, action)
@@ -59,7 +66,7 @@ class Coach():
             r = self.game.getGameEnded(board, self.curPlayer)
 
             if r!=0:
-                return [(x[0],x[2],r*((-1)**(x[1]!=self.curPlayer))) for x in trainExamples]
+                return [(x[0],x[2],r*((-1)**(x[1]!=self.curPlayer)),x[3]) for x in trainExamples]
 
     def learn(self):
         """

--- a/MCTS.py
+++ b/MCTS.py
@@ -76,8 +76,10 @@ class MCTS():
 
         if s not in self.Ps:
             # leaf node
-            self.Ps[s], v = self.nnet.predict(canonicalBoard)
+            
+            # see: https://github.com/suragnair/alpha-zero-general/issues/77
             valids = self.game.getValidMoves(canonicalBoard, 1)
+            self.Ps[s], v = self.nnet.predict((canonicalBoard, valids))
             self.Ps[s] = self.Ps[s]*valids      # masking invalid moves
             sum_Ps_s = np.sum(self.Ps[s])
             if sum_Ps_s > 0:

--- a/othello/tensorflow/NNet.py
+++ b/othello/tensorflow/NNet.py
@@ -52,10 +52,10 @@ class NNetWrapper(NeuralNet):
             # self.sess.run(tf.local_variables_initializer())
             while batch_idx < int(len(examples)/args.batch_size):
                 sample_ids = np.random.randint(len(examples), size=args.batch_size)
-                boards, pis, vs = list(zip(*[examples[i] for i in sample_ids]))
+                boards, pis, vs, valids = list(zip(*[examples[i] for i in sample_ids]))
 
                 # predict and compute gradient and do SGD step
-                input_dict = {self.nnet.input_boards: boards, self.nnet.target_pis: pis, self.nnet.target_vs: vs, self.nnet.dropout: args.dropout, self.nnet.isTraining: True}
+                input_dict = {self.nnet.input_boards: boards, self.nnet.target_pis: pis, self.nnet.target_vs: vs, self.nnet.valids: valids, self.nnet.dropout: args.dropout, self.nnet.isTraining: True}
 
                 # measure data loading time
                 data_time.update(time.time() - end)
@@ -86,18 +86,21 @@ class NNetWrapper(NeuralNet):
             bar.finish()
 
 
-    def predict(self, board):
+    def predict(self, boardAndValids):
         """
         board: np array with board
         """
         # timing
         start = time.time()
 
+        board, valids = boardAndValids
+
         # preparing input
         board = board[np.newaxis, :, :]
+        valids = valids[np.newaxis, :]
 
         # run
-        prob, v = self.sess.run([self.nnet.prob, self.nnet.v], feed_dict={self.nnet.input_boards: board, self.nnet.dropout: 0, self.nnet.isTraining: False})
+        prob, v = self.sess.run([self.nnet.prob, self.nnet.v], feed_dict={self.nnet.input_boards: board, self.nnet.valids: valids, self.nnet.dropout: 0, self.nnet.isTraining: False})
 
         #print('PREDICTION TIME TAKEN : {0:03f}'.format(time.time()-start))
         return prob[0], v[0]


### PR DESCRIPTION
This update has ONLY been applied to Othello's Tensorflow implementation. 
Awaiting confirmation that this is correct, and I will apply to it to the rest. 

This version is **not** compatible with previous version. None of the older saved models will run on this. 