### PR TITLE
Fix for best action choice

### DIFF
--- a/MCTS.py
+++ b/MCTS.py
@@ -35,7 +35,8 @@ class MCTS():
         counts = [self.Nsa[(s,a)] if (s,a) in self.Nsa else 0 for a in range(self.game.getActionSize())]
 
         if temp==0:
-            bestA = np.argmax(counts)
+            bestAs = np.array(np.argwhere(counts == np.max(counts))).flatten()
+            bestA = np.random.choice(bestAs)
             probs = [0]*len(counts)
             probs[bestA]=1
             return probs


### PR DESCRIPTION
Since counts is an integer, taking bestA = np.argmax(counts) always weights our action choice towards earlier entries (in the list of actions) when multiple (s,a) pairs have the same maximum count. We should pick randomly from the set of actions with maximum counts.