### PR TITLE
Removed negative zeros in board (-0.) by setting dtype to int.

### DIFF
--- a/connect4/Connect4Logic.py
+++ b/connect4/Connect4Logic.py
@@ -20,7 +20,7 @@ class Board():
         self.win_length = win_length or DEFAULT_WIN_LENGTH
 
         if np_pieces is None:
-            self.np_pieces = np.zeros([self.height, self.width])
+            self.np_pieces = np.zeros([self.height, self.width], dtype=np.int)
         else:
             self.np_pieces = np_pieces
             assert self.np_pieces.shape == (self.height, self.width)


### PR DESCRIPTION
An example:
The state ```[[-0. -0. -0. -0. -0. -0. -0.], [-0. -0. -0. -0. -0. -0. -0.], [-0. -0. -0. -0. -0. -0. -0.], [-0. -0. -0. -0. -0. -0. -0.], [-0. -0. -0. -0. -0. -0. -0.], [-1. -0. -0. -0. -0. -0. 1.]]``` and ```[[0. 0. 0. 0. 0. 0. 0.], [0. 0. 0. 0. 0. 0. 0.], [0. 0. 0. 0. 0. 0. 0.], [0. 0. 0. 0. 0. 0. 0.], [0. 0. 0. 0. 0. 0. 0.], [-1. 0. 0. 0. 0. 0. 1.]]``` were treated as different states because of the negative zeros.
By multiplying zeros which represented as floats with negative numbers (-1 in our case) leads to this representation.

Solution:
By setting the datatype explicitly to int, the zeros are invariant to negative multiplication.