### PR TITLE
Generalize pit file via pit config

### DIFF
--- a/Arena.py
+++ b/Arena.py
@@ -77,7 +77,7 @@ class Arena():
         oneWon = 0
         twoWon = 0
         draws = 0
-        for _ in tqdm(range(num), desc="Arena.playGames (1)"):
+        for _ in tqdm(range(num), desc="Arena.playGames (1)", disable=verbose):  # When using display() hide progressbar
             gameResult = self.playGame(verbose=verbose)
             if gameResult == 1:
                 oneWon += 1
@@ -88,7 +88,7 @@ class Arena():
 
         self.player1, self.player2 = self.player2, self.player1
 
-        for _ in tqdm(range(num), desc="Arena.playGames (2)"):
+        for _ in tqdm(range(num), desc="Arena.playGames (2)", disable=verbose):  # When using display() hide progressbar
             gameResult = self.playGame(verbose=verbose)
             if gameResult == -1:
                 oneWon += 1

--- a/othello/pit_config.py
+++ b/othello/pit_config.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from MCTS import MCTS
+from othello.OthelloGame import OthelloGame
+from othello.OthelloPlayers import RandomPlayer, GreedyOthelloPlayer, HumanOthelloPlayer
+from othello.pytorch.NNet import NNetWrapper as NNet
+from utils import dotdict
+
+
+def get_config():
+    mini_othello = False  # Play in 6x6 instead of the normal 8x8.
+    human_vs_cpu = True
+    if mini_othello:
+        g = OthelloGame(6)
+    else:
+        g = OthelloGame(8)
+    # all players
+    rp = RandomPlayer(g).play
+    gp = GreedyOthelloPlayer(g).play
+    hp = HumanOthelloPlayer(g).play
+    # nnet players
+    n1 = NNet(g)
+    if mini_othello:
+        n1.load_checkpoint('./pretrained_models/othello/pytorch/', '6x100x25_best.pth.tar')
+    else:
+        n1.load_checkpoint('./pretrained_models/othello/pytorch/', '8x8_100checkpoints_best.pth.tar')
+    args1 = dotdict({'numMCTSSims': 50, 'cpuct': 1.0})
+    mcts1 = MCTS(g, n1, args1)
+    n1p = lambda x: np.argmax(mcts1.getActionProb(x, temp=0))
+    if human_vs_cpu:
+        player2 = hp
+    else:
+        n2 = NNet(g)
+        n2.load_checkpoint('./pretrained_models/othello/pytorch/', '8x8_100checkpoints_best.pth.tar')
+        args2 = dotdict({'numMCTSSims': 50, 'cpuct': 1.0})
+        mcts2 = MCTS(g, n2, args2)
+        n2p = lambda x: np.argmax(mcts2.getActionProb(x, temp=0))
+
+        player2 = n2p  # Player 2 is neural network if it's cpu vs cpu.
+    player1 = n1p
+    game = g
+    return player1, player2, game

--- a/pit.py
+++ b/pit.py
@@ -1,54 +1,44 @@
-import Arena
-from MCTS import MCTS
-from othello.OthelloGame import OthelloGame
-from othello.OthelloPlayers import *
-from othello.pytorch.NNet import NNetWrapper as NNet
-
-
-import numpy as np
-from utils import *
-
 """
 use this script to play any two agents against each other, or play manually with
 any agent.
 """
+import argparse
+import importlib
+import logging
+import sys
 
-mini_othello = False  # Play in 6x6 instead of the normal 8x8.
-human_vs_cpu = True
+import coloredlogs
 
-if mini_othello:
-    g = OthelloGame(6)
-else:
-    g = OthelloGame(8)
+import Arena
 
-# all players
-rp = RandomPlayer(g).play
-gp = GreedyOthelloPlayer(g).play
-hp = HumanOthelloPlayer(g).play
+log = logging.getLogger(__name__)
+coloredlogs.install(level='INFO')  # Change this to DEBUG to see more info.
 
 
+class HelperParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.print_help()
 
-# nnet players
-n1 = NNet(g)
-if mini_othello:
-    n1.load_checkpoint('./pretrained_models/othello/pytorch/','6x100x25_best.pth.tar')
-else:
-    n1.load_checkpoint('./pretrained_models/othello/pytorch/','8x8_100checkpoints_best.pth.tar')
-args1 = dotdict({'numMCTSSims': 50, 'cpuct':1.0})
-mcts1 = MCTS(g, n1, args1)
-n1p = lambda x: np.argmax(mcts1.getActionProb(x, temp=0))
+        sys.stderr.write('\nerror: %s\n' % message)
+        sys.exit(2)
 
-if human_vs_cpu:
-    player2 = hp
-else:
-    n2 = NNet(g)
-    n2.load_checkpoint('./pretrained_models/othello/pytorch/', '8x8_100checkpoints_best.pth.tar')
-    args2 = dotdict({'numMCTSSims': 50, 'cpuct': 1.0})
-    mcts2 = MCTS(g, n2, args2)
-    n2p = lambda x: np.argmax(mcts2.getActionProb(x, temp=0))
 
-    player2 = n2p  # Player 2 is neural network if it's cpu vs cpu.
+parser = HelperParser(description='Pit two players against each other.')
+parser.add_argument('--game', '-g', type=str, help='game directory (i.e. othello)', required=True)
 
-arena = Arena.Arena(n1p, player2, g, display=OthelloGame.display)
 
-print(arena.playGames(2, verbose=True))
+def main(args):
+    full_module_name = args.game + '.' + 'pit_config'
+    try:
+        game_module = importlib.import_module(full_module_name)
+    except Exception as e:
+        log.error('Could not load game "%s": %s' % (args.game, e))
+        log.error('Make sure "%s" directory exists and it has "pit_config.py" file in it' % args.game)
+        sys.exit(2)
+    player1, player2, game = game_module.get_config()
+    arena = Arena.Arena(player1, player2, game, game.display)
+    print(arena.playGames(2, verbose=True))
+
+
+if __name__ == '__main__':
+    main(parser.parse_args())

--- a/rts/pit.py
+++ b/rts/pit.py
@@ -14,5 +14,6 @@ Compares 2 players against each other and outputs num wins p1/ num wins p2/ draw
 CONFIG.set_runner('pit')  # set visibility as pit
 g = RTSGame()
 player1, player2 = CONFIG.pit_args.create_players(g)
+
 arena = Arena.Arena(player1, player2, g, display=display)
 print(arena.playGames(CONFIG.pit_args.num_games, verbose=CONFIG.visibility))


### PR DESCRIPTION
This isn't super tidy, but i think it's the right step forward.

```text
$ python pit.py
usage: pit.py [-h] --game GAME

Pit two players against each other.

optional arguments:
  -h, --help            show this help message and exit
  --game GAME, -g GAME  game directory (i.e. othello)

error: the following arguments are required: --game/-g
```

and with the argument

```
$ python pit.py -g othello
Turn  1 Player  1
   0 1 2 3 4 5 6 7
-----------------------
0 |- - - - - - - - |
1 |- - - - - - - - |
2 |- - - - - - - - |
3 |- - - X O - - - |
4 |- - - O X - - - |
5 |- - - - - - - - |
6 |- - - - - - - - |
7 |- - - - - - - - |
-----------------------
```