### PR TITLE
Change MCTS to use game.getCanonicalForm() for inverting the response

### DIFF
--- a/MCTS.py
+++ b/MCTS.py
@@ -99,7 +99,7 @@ class MCTS():
 
             self.Vs[s] = valids
             self.Ns[s] = 0
-            return -v
+            return self.game.getCanonicalForm(canonicalBoard, -1)
 
         valids = self.Vs[s]
         cur_best = -float('inf')
@@ -133,4 +133,4 @@ class MCTS():
             self.Nsa[(s, a)] = 1
 
         self.Ns[s] += 1
-        return -v
+        return self.game.getCanonicalForm(canonicalBoard, -1)

--- a/MCTS.py
+++ b/MCTS.py
@@ -99,7 +99,7 @@ class MCTS():
 
             self.Vs[s] = valids
             self.Ns[s] = 0
-            return self.game.getCanonicalForm(canonicalBoard, -1)
+            return self.game.getCanonicalForm(v, -1)
 
         valids = self.Vs[s]
         cur_best = -float('inf')
@@ -133,4 +133,4 @@ class MCTS():
             self.Nsa[(s, a)] = 1
 
         self.Ns[s] += 1
-        return self.game.getCanonicalForm(canonicalBoard, -1)
+        return self.game.getCanonicalForm(v, -1)


### PR DESCRIPTION
MCTS assumes that board difference between P1 and P2 is strictly negativity.
In case the data is more complex than that we can rely on already-required getCanonicalForm() method of the Game.