### PR TITLE
Remove MANY oldest trainExamples if needed

### DIFF
--- a/Coach.py
+++ b/Coach.py
@@ -91,7 +91,7 @@ class Coach():
                 # save the iteration examples to the history 
                 self.trainExamplesHistory.append(iterationTrainExamples)
 
-            if len(self.trainExamplesHistory) > self.args.numItersForTrainExamplesHistory:
+            while len(self.trainExamplesHistory) > self.args.numItersForTrainExamplesHistory:
                 log.warning(
                     f"Removing the oldest entry in trainExamples. len(trainExamplesHistory) = {len(self.trainExamplesHistory)}")
                 self.trainExamplesHistory.pop(0)


### PR DESCRIPTION
If the value for `numItersForTrainExamplesHistory` is adjusted mid training the Coach was only removing at most 1 old value. This change removes old values until the new history size is correct.