### PR TITLE
Use Miniconda-py37 instead of latest 3.8 version.

### DIFF
--- a/docker/Dockerfile.pytorch
+++ b/docker/Dockerfile.pytorch
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
      rm -rf /var/lib/apt/lists/*
 
 # Install miniconda, pytorch and other useful python libraries
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh  && \
 chmod +x ~/miniconda.sh && \
 ~/miniconda.sh -b -p /opt/conda && \
 rm ~/miniconda.sh && \


### PR DESCRIPTION
For compatibility with pytorch=0.4.1, I needed python 3.7 and not the latest build for linux (which is currently 3.8).