### PR TITLE
Updated logging arguments

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def main():
     nnet = nn(g)
 
     if args.load_model:
-        log.info('Loading checkpoint "%s/%s"...', args.load_folder_file)
+        log.info('Loading checkpoint "%s/%s"...', args.load_folder_file[0], args.load_folder_file[1])
         nnet.load_checkpoint(args.load_folder_file[0], args.load_folder_file[1])
     else:
         log.warning('Not loading a checkpoint!')


### PR DESCRIPTION
If `args.load_model` is true, we are going to load the checkpoint. 
However, the `log.info()` is expecting two strings to be formatted. This raises error on Python 3.8.8.
Add two arguments instead of one.