### PR TITLE
Add Othello player that can play with external programs using GTP

### DIFF
--- a/Arena.py
+++ b/Arena.py
@@ -41,6 +41,11 @@ class Arena():
         curPlayer = 1
         board = self.game.getInitBoard()
         it = 0
+
+        for player in players[0], players[2]:
+            if hasattr(player, "startGame"):
+                player.startGame()
+
         while self.game.getGameEnded(board, curPlayer) == 0:
             it += 1
             if verbose:
@@ -55,7 +60,18 @@ class Arena():
                 log.error(f'Action {action} is not valid!')
                 log.debug(f'valids = {valids}')
                 assert valids[action] > 0
+
+            # Notifying the opponent for the move
+            opponent = players[-curPlayer + 1]
+            if hasattr(opponent, "notify"):
+                opponent.notify(board, action)
+
             board, curPlayer = self.game.getNextState(board, curPlayer, action)
+
+        for player in players[0], players[2]:
+            if hasattr(player, "endGame"):
+                player.endGame()
+
         if verbose:
             assert self.display
             print("Game over: Turn ", str(it), "Result ", str(self.game.getGameEnded(board, 1)))

--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ Some extensions have been implented [here](https://github.com/kevaday/alphazero-
 * [Adam Lawson](https://github.com/goshawk22) contributed rules and a trained model for 3D TicTacToe.
 * [Carlos Aguayo](https://github.com/carlos-aguayo) contributed rules and a trained model for Dots and Boxes along with a [JavaScript implementation](https://github.com/carlos-aguayo/carlos-aguayo.github.io/tree/master/alphazero).
 * [Robert Ronan](https://github.com/rlronan) contributed rules for Santorini.
+* [Plamen Totev](https://github.con/plamentotev) contributed Go Text Protocol player for Othello.
 
 Note: Chainer and TensorFlow v1 versions have been removed but can be found prior to commit [2ad461c](https://github.com/suragnair/alpha-zero-general/tree/2ad461c393ecf446e76f6694b613e394b8eb652f).

--- a/othello/OthelloPlayers.py
+++ b/othello/OthelloPlayers.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import subprocess
 
 class RandomPlayer():
     def __init__(self, game):
@@ -56,3 +56,103 @@ class GreedyOthelloPlayer():
             candidates += [(-score, a)]
         candidates.sort()
         return candidates[0][1]
+
+class GTPOthelloPlayer():
+    """
+    Player that plays with Othello programs using the Go Text Protocol.
+    """
+
+    # The colours are reversed as the Othello programs seems to have the board setup with the opposite colours
+    player_colors = {
+        -1: "white",
+         1: "black",
+    }
+
+    def __init__(self, game, gtpClient):
+        """
+        Input:
+            game: the game instance
+            gtpClient: list with the command line arguments to start the GTP client with.
+                       The first argument should be the absolute path to the executable.
+        """
+        self.game = game
+        self.gtpClient = gtpClient
+
+    def startGame(self):
+        """
+        Should be called before the game starts in order to setup the board.
+        """
+        self._currentPlayer = 1 # Arena does not notify players about their colour so we need to keep track here
+        self._process = subprocess.Popen(self.gtpClient, bufsize = 0, stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+        self._sendCommand("boardsize " + str(self.game.n))
+        self._sendCommand("clear_board")
+
+    def endGame(self):
+        """
+        Should be called after the game ends in order to clean-up the used resources.
+        """
+        if hasattr(self, "_process") and self._process is not None:
+            self._sendCommand("quit")
+            # Waits for the client to terminate gracefully for 10 seconds. If it does not - kills it.
+            try:
+                self._process.wait(10)
+            except (subprocessTimeoutExpired):
+                self._process.kill()
+            self._process = None
+
+    def notify(self, board, action):
+        """
+        Should be called after the opponent turn. This way we can update the GTP client with the opponent move.
+        """
+        color = GTPOthelloPlayer.player_colors[self._currentPlayer]
+        move = self._convertActionToMove(action)
+        self._sendCommand("play {} {}".format(color, move))
+        self._switchPlayers()
+
+    def play(self, board):
+        color = GTPOthelloPlayer.player_colors[self._currentPlayer]
+        move = self._sendCommand("genmove {}".format(color))
+        action = self._convertMoveToAction(move)
+        self._switchPlayers()
+        return action
+
+    def _switchPlayers(self):
+        self._currentPlayer = -self._currentPlayer
+
+    def _convertActionToMove(self, action):
+        if action < self.game.n ** 2:
+            row, col = int(action / self.game.n), int(action % self.game.n)
+            return "{}{}".format(chr(ord("A") + col), row + 1)
+        else:
+            return "PASS"
+
+    def _convertMoveToAction(self, move):
+        if move != "PASS":
+            col, row = ord(move[0]) - ord('A'), int(move[1:])
+            return (row - 1) * self.game.n + col
+        else:
+            return self.game.n ** 2
+
+    def _sendCommand(self, cmd):
+        self._process.stdin.write(cmd.encode() + b"\n")
+
+        response = ""
+        while True:
+            line = self._process.stdout.readline().decode()
+            if line == "\n":
+                if response:
+                    break  # Empty line means end of the response is reached
+                else:
+                    continue  # Ignoring leading empty lines
+            response += line
+
+        # If the first character of the response is '=', then is success. '?' is error.
+        if response.startswith("="):
+            # Some clients return uppercase other lower case.
+            # Normalizing to uppercase in order to simplify handling.
+            return response[1:].strip().upper()
+        else:
+            raise Exception("Error calling GTP client: {}".format(response[1:].strip()))
+
+    def __call__(self, game):
+        return self.play(game)

--- a/othello/README.md
+++ b/othello/README.md
@@ -1,0 +1,34 @@
+# Othello
+
+[Othello](https://en.wikipedia.org/wiki/Reversi) is a two player board game, usually played on an 8x8 board.
+
+### Go Text Protocol Player
+
+[Go Text Protocol](https://en.wikipedia.org/wiki/Go_Text_Protocol) (GTP) is a text protocol that allows Go (the game, not the programming language) programs to play with each other. Due to the similarity in the board representation the protocol is used by Othello/Reversi programs.
+`GTPOthelloPlayer` allows a game to be played with external Othello program. This could be useful to test Othello player versus existing Othello programs.
+
+#### Usage
+
+Creating `GTPOthelloPlayer` instance and using it is straightforward:
+
+    player = GTPOthelloPlayer(game, ["/path/to/bin/executable", "-gtp", "-l", "10"])
+    player.startGame() # runs he external program
+    # the game loop
+    player.endGame() # stops the external program
+
+`/path/to/bin/executable` is the absolute path to the executable of the Othello program and the rest of the list are the arguments passed to it during startup time. If you're using `Arena` you must not call `startGame` and `endGame`, as it already does it:
+
+    randomPlayer = RandomPlayer(game).play
+    gtpPlayer = GTPOthelloPlayer(game, ["/path/to/bin/executable", "-gtp", "-l", "10"])
+    
+    arena = Arena(randomPlayer, gtpPlayer, game, display=OthelloGame.display)
+
+Notice that the `GTPOthelloPlayer` instance is passed to `Arena`, not a reference to `play`. This allows `Arena` to call various methods, such as `startGame` and `endGame`, mentioned above.
+
+#### Limitations
+
+The different Othello programs has varying support for GTP, which is not intended to play Othello in first place, so there are some limitations when using this player. The implementation was tested with [Egaroucid](https://github.com/Nyanyan/Egaroucid) and [Edax](https://github.com/abulmo/edax-reversi), but hopefully it would work with other programs as well.
+
+* GTP allows varying board sizes, but both Egaroucid and Edax support only 8x8 board
+* Player `1` (not `-1`) always starts the game. This aligns with how Arena handles the games
+* There is no way to set the state on each move. To account for that after each move of the opponent `notify` must be called. It will sent the move to the external programs so it has the same state about the game. It must not be called for the move made by `GTPOthelloPlayer` as the external program has already modified it own state with it. `Arena` already does that so you don't have to do it yourself if you're using it.


### PR DESCRIPTION
GTP (Go Text Protocol) is a text protocol that allows Go (the game, not the programming language) programs to play with each other. Due to the similarity in the board representation the protocol is used by Othello/Reversi programs.

Add Othello player that uses the protocol to play with external programs. That makes it easy to test how well the AI performs against other AI bots.

Add some additional methods to the Player interface - startGame, endGame and notify. Those methods are essential to keep the state synced with external program.

Update Arena to use those methods if present to keep it backward compatible and not to force other implementations to implement class. To this end GTPOthelloPlayer is callable so that players can still be a simple function.

Using the player in `pit.py` is pretty straightforward:

    player2 = GTPOthelloPlayer(g, ["/path/to/bin/Egaroucid_for_Console", "-gtp"])

I've tested it with [Egaroucid](https://github.com/Nyanyan/Egaroucid) and [Edax](https://github.com/abulmo/edax-reversi)